### PR TITLE
Remove binary chars in jupyter notebook

### DIFF
--- a/notebooks/WGAN-GP_minimal.ipynb
+++ b/notebooks/WGAN-GP_minimal.ipynb
@@ -470,4 +470,3 @@
  "nbformat": 4,
  "nbformat_minor": 1
 }
-            


### PR DESCRIPTION
The last line of the jupyter notebook had a few characters preventing Github from rendering the notebook in browser. I removed the binary crud. CC @arshamg 